### PR TITLE
Add tags to licenses.json

### DIFF
--- a/pull.py
+++ b/pull.py
@@ -165,6 +165,8 @@ def save(licenses, dir=os.curdir):
         index[id] = {'name': license['name']}
         if 'identifiers' in license:
             index[id]['identifiers'] = license['identifiers']
+        if 'tags' in license:
+                index[id]['tags'] = sorted(license['tags'])
     with open(os.path.join(dir, 'licenses.json'), 'w') as f:
         json.dump(obj=index, fp=f, indent=2, sort_keys=True)
         f.write('\n')


### PR DESCRIPTION
I would like to suggest adding the tags to the licenses.json file.  This would make the [SPDX License Generator Tool](https://github.com/spdx/tools/blob/master/src/org/spdx/tools/LicenseRDFAGenerator.java) implementation simpler and more efficient.  It may also help other consumers of the FSF API by not requiring them to read the individual JSON files for some of the more interesting information stored in the tags.

The resultant ```licenses.json``` file size is < 22 KB.

The file ```licenses.json``` prior to this change is 14 KB.

I would consider the additional size a reasonable trade-off for easier access to the additional information.