### PR TITLE
pull: Add the FSF ID to per-license files as 'id'

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ You can pull an individual license from a few places:
 
 Licenses have the following properties:
 
-* FSF ID: a short slug identifying the license.
+* `id`: a short slug identifying the license.
+    In [`licenses-full.json`](#licenses-full.json), this is information is in the in root object key and not duplicated in the value.
 * `name`: a short string naming the license.
 * `uris`: an array of URIs for the license.
     The first entry in this array will always be an entry on the [the FSF's HTML page][fsf-list].

--- a/pull.py
+++ b/pull.py
@@ -286,7 +286,8 @@ def save(licenses, dir=os.curdir):
         license = license.copy()
         if 'tags' in license:
             license['tags'] = sorted(license['tags'])
-        full_index[id] = license
+        full_index[id] = license.copy()
+        license['id'] = id
         license_path = os.path.join(dir, '{}.json'.format(id))
         with open(license_path, 'w') as f:
             json.dump(obj=license, fp=f, indent=2, sort_keys=True)


### PR DESCRIPTION
This allows you to convert an SPDX ID back to a FSF ID:

```console
$ curl -s https://wking.github.io/fsf-api/spdx/MIT.json | jq -r .id
Expat
```

without scraping the information out of `uris`.