### PR TITLE
pull: Split SILOFL into SILOFL-1.0 and SILOFL-1.1

### DIFF
--- a/pull.py
+++ b/pull.py
@@ -76,6 +76,10 @@ SPLITS = {
         'Python2.0',
         'Python2.1',
     ],
+    'SILOFL': [ # title has 1.1 but text says the same metadata applies to 1.0
+        'SILOFL-1.0',
+        'SILOFL-1.1',
+    ],
     'Zope2.0': [ # versions 2.0 and 2.1
         'Zope2.0',
         'Zope2.1',
@@ -194,7 +198,8 @@ IDENTIFIERS = {
     'RPSL': {'spdx': ['RPSL-1.0']},
     'Ruby': {'spdx': ['Ruby']},
     'SGIFreeB': {'spdx': ['SGI-B-2.0']},
-    'SILOFL': {'spdx': ['OFL-1.1']},
+    'SILOFL-1.0': {'spdx': ['OFL-1.0']},
+    'SILOFL-1.1': {'spdx': ['OFL-1.1']},
     'SPL': {'spdx': ['SPL-1.0']},
     'StandardMLofNJ': {'spdx': ['SMLNJ', 'StandardML-NJ']},
     'Unlicense': {'spdx': ['Unlicense']},


### PR DESCRIPTION
The title and linked text are for 1.1, but [the description][1] includes:

> The Open Font License (including its original release, version 1.0) is a free copyleft license for fonts...

as [reported][2] by @donaldr3.

It would be nice if the FSF had separate identifiers or at least linked to their version of the 1.0 text; for now I'm just minting my own versioned identifiers in `SPLITS` and allowing the `SILOFL-1.0` JSON to include the link to the 1.1 text in its `uris` property.

[1]: https://www.gnu.org/licenses/license-list.en.html#SILOFL
[2]: https://github.com/wking/fsf-api/issues/7#issuecomment-391093115