### PR TITLE
pull: Remove obsolete "not in license-list-XML" comment for EPL2

### DIFF
--- a/pull.py
+++ b/pull.py
@@ -141,7 +141,7 @@ IDENTIFIERS = {
     'eCos11': {'spdx': ['RHeCos-1.1']},
     'eCos2.0': {'spdx': ['GPL-2.0+ WITH eCos-exception-2.0', 'eCos-2.0']},
     'EPL': {'spdx': ['EPL-1.0']},
-    'EPL2': {'spdx': ['EPL-2.0']}, # not in license-list-XML yet
+    'EPL2': {'spdx': ['EPL-2.0']},
     'EUDataGrid': {'spdx': ['EUDatagrid']},
     'EUPL': {'spdx': ['EUPL-1.1']},
     'Eiffel': {'spdx': ['EFL-2.0']},


### PR DESCRIPTION
The comment was current when it was added in 66d83402, but the EPL-2.0 license [was part of the 3.0 license list][1].

[1]: https://github.com/spdx/license-list-XML/blob/v3.0/src/EPL-2.0.xml